### PR TITLE
Remove streaming API parameters

### DIFF
--- a/streaming-api-client/README.md
+++ b/streaming-api-client/README.md
@@ -139,7 +139,7 @@ python3 wsclient_public.py --help
 
 The required script arguments are,
 
-- `--hostname` - The base url obtained from Aruba Central `Account Home -> Webhooks -> Streaming -> Endpoint`. For example "wss://**internal-ui.central.arubanetworks.com**/streaming/api"
+- `--hostname` - The base url obtained from Aruba Central `Maintain -> Organization -> Platform Integration -> API Gateway -> Streaming -> Endpoint`. For example "wss://**internal-ui.central.arubanetworks.com**/streaming/api"
 
 - `--jsoninput` - Input File where the Aruba Central customer information is provided in JSON format.
 
@@ -149,8 +149,6 @@ To view data on screen,
 Complete list of arguments accepted by the script
 ```
   wsclient_public.py [-h] --hostname HOSTNAME --jsoninput JSONINPUT
-                          [--start_seq START_SEQ] [--deliver_last]             
-                          [--deliver_all] [--since_time SINCE_TIME]
                           [--decode_data] [--no_valid_cert]
                           [--export_data EXPORT_DATA]
  ```                         
@@ -178,7 +176,7 @@ This format is to subscribe to a single topic for a single customer
 
 - "username" --> A valid central user email address through which Streaming API will be accessed
 
-- "wsskey" --> obtained from Aruba Central (Account Home -> Webhooks -> Streaming -> Key)
+- "wsskey" --> obtained from Aruba Central (`Maintain -> Organization -> Platform Integration -> API Gateway -> Streaming -> Streaming Key`)
 
 - "topic" --> provide one of the following [audit, apprf, location, monitoring, presence, security]
 

--- a/streaming-api-client/wsclient_public.py
+++ b/streaming-api-client/wsclient_public.py
@@ -57,19 +57,6 @@ def define_arguments():
                         required=True,
                         help='Json input file containing customers details \
                         such as username, wsskey and topic to subscribe.')
-    parser.add_argument('--start_seq', required=False,
-                        help='A valid sequence number to start getting \
-                        events from that sequence (optional)')
-    parser.add_argument('--deliver_last', required=False,
-                        help='X-Deliver-Last get latest events (Optional)',
-                        action='store_true')
-    parser.add_argument('--deliver_all', required=False,
-                        help='Deliver-All get all events(optional)',
-                        action='store_true')
-    parser.add_argument('--since_time', required=False,
-                        help='X-Since-Time receive events after the time \
-                        stamp in predefined string format like 1h, 5m, 10s \
-                        etc (optional)')
     parser.add_argument('--decode_data', required=False,
                         help='Print the decoded data on screen',
                         action='store_true')
@@ -104,14 +91,6 @@ def process_arguments(args):
         sys.exit("Error: json file does not have 'customers' list. "
                  "exiting...")
 
-    if args.start_seq is not None:
-        header['X-Start-Seq'] = int(args.start_seq)
-    if args.deliver_last:
-        header['X-Deliver-Last'] = "true"
-    if args.deliver_all:
-        header['X-Deliver-All'] = "true"
-    if args.since_time is not None:
-        header['X-Since-Time'] = args.since_time
 
     param_dict['no_valid_cert'] = args.no_valid_cert
     if args.no_valid_cert:


### PR DESCRIPTION
Streaming API parameters that are no longer supported have been removed from the wsclient_public python script-
1. start_seq
2. deliver_last
3. deliver_all
4. since_time