### PR TITLE
Added MSP customer deletion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains Python based workflows & code samples that utilize [Aru
 - [Device Onboarding](https://github.com/aruba/central-python-workflows/tree/main/device_onboarding) 
   ![Device Onboarding Demo Workflow](device_onboarding/media/workflow_overview.png)
 - [MSP Customer Onboarding](https://github.com/aruba/central-python-workflows/tree/main/msp_customer_onboarding) 
-  ![Device Onboarding Demo Workflow](msp_customer_onboarding/media/workflow_overview.png)
+  ![MSP Customer Onboarding Demo Workflow](msp_customer_onboarding/media/workflow_overview.png)
+- [MSP Customer Deletion](https://github.com/aruba/central-python-workflows/tree/main/msp_customer_deletion)
 - [Inventory to Excel Workflows](https://github.com/aruba/central-python-workflows/tree/main/inventory_to_excel)\
   This workflow creates excel files populated with device details from devices currently in inventory.
 - [AP CLI Workflows](https://github.com/aruba/central-python-workflows/tree/main/ap_config)

--- a/msp_customer_deletion/README.md
+++ b/msp_customer_deletion/README.md
@@ -1,0 +1,88 @@
+# MSP Customer Deletion
+This is a Python script that uses the [Pycentral](https://pypi.org/project/pycentral/) library to achieve the following steps on an Aruba Central account with [MSP mode](https://www.arubanetworks.com/techdocs/central/latest/content/nms/msp/overview.htm)- 
+1. Unassigns all devices & subscriptions from a customer's Aruba Central Instance
+2. Deletes the customer's Aruba Central & Greenlake instance
+
+## WARNING 
+When this script is executed for a customer account, 
+1. All users will lose access to the customer account 
+2. It will permanently delete all device and user data in the customer account. 
+3. All devices & subscriptions will be moved to the MSP's inventory. 
+4. The customer's Central & Greenlake Instance will be deleted
+**This actions is irreversable and cannot be canceled or undone once the script has begun.**
+
+## Installation Steps
+In order to run the script, please complete the steps below:
+1. Clone this repository and `cd` into the workflow directory:
+    ```bash
+    git clone https://github.com/aruba/central-python-workflows
+    cd central-python-workflows/msp_customer_deletion
+    ```
+   
+2. Install virtual environment (refer https://docs.python.org/3/library/venv.html). Make sure python version 3 is installed in system.
+    ```bash
+    python -m venv env
+    ```
+
+3. Activate the virtual environment
+    In Mac/Linux:
+    ```bash
+    source env/bin/activate
+    ```
+    In Windows:
+    ```bash
+    env/Scripts/activate.bat
+    ```
+4. Install the packages required for the script
+    ```bash
+    python -m pip install -r requirements.txt
+    ```
+5. Provide the Central API Gateway Base URL & Access Token in the [central_token.json](central_token.json)
+    ```json
+    {
+        "central_info": {
+            "base_url": "<api-gateway-domain-url>",
+            "token": {
+                "access_token": "<api-gateway-access-token>"
+            }
+        },
+        "ssl_verify": true
+    }
+    ```
+    **Note**
+   - [BaseURLs of Aruba Central Clusters](https://developer.arubanetworks.com/aruba-central/docs/api-oauth-access-token#table-domain-urls-for-api-gateway-access)
+   - [Generating Access token from Central UI](https://developer.arubanetworks.com/aruba-central/docs/api-gateway-creating-application-token)
+   - [Generating Access token using OAuth APIs](https://developer.arubanetworks.com/aruba-central/docs/api-oauth-access-token)
+6. Provide the names OR IDs of the customers that has to be deleted with the script. You only need to provide one of these attributes for the script. You also have the option to provide IDs for some customers & names for other customers that have to be deleted.
+   ```json
+    {
+        "customer_ids": [ 
+            "<customer_1_id>",
+            "<customer_2_id>"
+        ],
+        "customer_names": [
+            "<customer_3_name>",
+            "<customer_4_name>"
+        ]
+    }
+    ```
+    **Note**
+    - If you provide the customer name, the script will perform additional API calls to Central to fetch the ID of the customer. This ID is needed to run deletion API calls on the customer.
+    - You can find out the ID of a customer in MSP mode using this [API](https://developer.arubanetworks.com/aruba-central/docs/onboarding-a-customer#get-the-customer-id-of-the-new-customer)
+7. Once **central_token.json** & **workflow_variables.json** are updated with the relevant information, you can execute the script with the following command:
+   ```bash
+    python msp_customer_deletion.py
+    ```
+    **Note**  
+    - This script takes the following optional parameters to overide default filenames for the script
+      - central_auth - Path of Central Token File
+      - workflow_variables - Path of Workflows Variables File  
+    - You can run the following command to use the optional parameters -
+     ```bash
+    python msp_customer_deletion.py --central_auth <central_token_file> --workflow_variables <workflow_variables_file>
+    ```
+
+## Central APIs used for this workflow - 
+1. [Get list of customers under the MSP account based on limit and offset](https://developer.arubanetworks.com/aruba-central/reference/apiviewsmsp_apiget_customers)
+2. [Un-assign all devices from Tenant/end-customer](https://developer.arubanetworks.com/aruba-central/reference/apiviewsmsp_apiunassign_tenant_devices)
+3. [Delete a customer](https://developer.arubanetworks.com/aruba-central/reference/apiviewsmsp_apidelete_customer)

--- a/msp_customer_deletion/central_token.json
+++ b/msp_customer_deletion/central_token.json
@@ -1,8 +1,8 @@
 {
     "central_info": {
-        "base_url": "https://internal-apigw.central.arubanetworks.com/",
+        "base_url": "<api-gateway-domain-url>",
         "token": {
-            "access_token": "5Gzn28K0XWbmXReFIgXoyfyjgDi0ouLE"
+            "access_token": "<api-gateway-access-token>"
         }
     },
     "ssl_verify": true

--- a/msp_customer_deletion/central_token.json
+++ b/msp_customer_deletion/central_token.json
@@ -1,0 +1,9 @@
+{
+    "central_info": {
+        "base_url": "https://internal-apigw.central.arubanetworks.com/",
+        "token": {
+            "access_token": "5Gzn28K0XWbmXReFIgXoyfyjgDi0ouLE"
+        }
+    },
+    "ssl_verify": true
+}

--- a/msp_customer_deletion/msp_customer_deletion.py
+++ b/msp_customer_deletion/msp_customer_deletion.py
@@ -1,0 +1,144 @@
+from termcolor import colored
+from pycentral.workflows.workflows_utils import get_conn_from_file
+from argparse import ArgumentParser
+from pycentral.msp import MSP
+from halo import Halo
+import json
+import sys
+m = MSP()
+
+
+def main():
+    # Define Command-line Arguments
+    args = define_arguments()
+
+    # Get instance of ArubaCentralBase from the central_filename
+    global central_conn
+    central_conn = get_conn_from_file(filename=args.central_auth)
+
+    # Load in Workflow Variables
+    customer_list = json.loads(open(args.customer_list, "r").read())
+    delete_customer_ids = get_customer_ids(customer_list)
+    user_confirmation(delete_customer_ids)
+
+    delete_status = list(map(delete_customer, delete_customer_ids))
+    successful_customers = []
+    error_customers = []
+    for delete_status, customer_id in zip(delete_status, delete_customer_ids):
+        if (delete_status == False):
+            error_customers.append(customer_id)
+        else:
+            successful_customers.append(customer_id)
+    if len(successful_customers) > 0:
+        print(
+            f'Successfully deleted customer(s) with ID - {colored(", ".join(successful_customers), "blue")}')
+    if len(error_customers) > 0:
+        print(
+            f'Error deleting customer(s) with ID - {colored(", ".join(error_customers), "red")}')
+
+
+def define_arguments():
+    """This function defines the command line arguments that can be used with this PyCentral script
+
+    Returns:
+        argparse.Namespace: Returns argparse namespace with central authorization & workflow variables file names
+    """
+
+    description = 'This script unassigns devices & subscriptions from the provided customers\' Aruba Central Instance, and then deletes the customers\'s Greenlake account.'
+
+    parser = ArgumentParser(description=description)
+    parser.add_argument(
+        '--central_auth', help=('Central API Authorization file path'), default='central_token.json')
+    parser.add_argument(
+        '--customer_list', help=('Customer List file path'), default='workflow_variables.json')
+    return parser.parse_args()
+
+
+def get_customer_ids(customer_list):
+    all_customers = m.get_all_customers(central_conn)
+    customer_ids = []
+    if 'customer_ids' in customer_list and len(customer_list['customer_ids']) > 0:
+        for customer_id in customer_list['customer_ids']:
+            if any(customer['customer_id'] == customer_id for customer in all_customers):
+                customer_ids.append(customer_id)
+            else:
+                sys.exit(colored(
+                    f"Unable to find customer with ID {customer_id} in MSP account. Please provide a valid customer ID.", 'red'))
+
+    if 'customer_names' in customer_list and len(customer_list['customer_names']) > 0:
+        for name in customer_list['customer_names']:
+            result = next(
+                (customer for customer in all_customers if customer['customer_name'] == name), None)
+            if result:
+                customer_ids.append(result['customer_id'])
+            else:
+                sys.exit(colored(
+                    f"Unable to find customer {name} in MSP account. Please provide a valid customer name.", 'red'
+                ))
+
+    if len(customer_ids) == 0:
+        sys.exit(colored(
+            "Customer list is empty. Please provide either the ID or the name of the customer you would like to delete.", 'red'))
+    return customer_ids
+
+
+def get_customer_id(customer_name):
+    customer_id = m.get_customer_id(central_conn, customer_name)
+    if customer_id is None:
+        sys.exit(colored(
+            f"Unable to find customer {customer_name} in MSP account. Please provide a valid customer name.", 'red'
+        ))
+    return customer_id
+
+
+def user_confirmation(delete_customer_ids):
+    customer_id_list = f'{len(delete_customer_ids)} customers({", ".join(delete_customer_ids)})'
+    confirmationText = f"""The script will be executed for {colored(customer_id_list, 'blue')} in the MSP account
+Continuing this script will do the following to the above mentioned customer account(s) -
+    1. All users will lose access to the customer account 
+    2. It will permanently delete all device and user data in the customer account. 
+    3. All devices & subscriptions will be moved to the MSP's inventory. 
+    4. The customer's Central & Greenlake Instance will be deleted
+"""
+    print(confirmationText)
+    userInput = input(
+        colored("Would you like to proceed with the script (y/n)? ", "yellow"))
+    if userInput.lower() == "y":
+        print(colored("Continuing...", "blue"))
+    else:
+        sys.exit(colored("Exiting script..", "red"))
+
+
+def delete_customer(customer_id):
+    unassign_step = unassign_customer_devices(customer_id)
+    if unassign_step:
+        delete_step = delete_customer_instance(customer_id)
+        if delete_step:
+            return True
+    return False
+
+
+@Halo(text='Unassigning devices & licenses from customer\'s Central instance...', spinner='simpleDots')
+def unassign_customer_devices(customer_id):
+    resp = m.unassign_all_customer_device(
+        central_conn, customer_id=customer_id)
+    if resp['code'] != 200:
+        print(
+            colored(f'Unable to unassign all devices from customer with ID - {customer_id}', 'red'))
+        return False
+    return True
+
+
+@Halo(text='Deleting customer\'s Central instance & Greenlake account...', spinner='simpleDots')
+def delete_customer_instance(customer_id):
+    resp = m.delete_customer(
+        central_conn, customer_id=customer_id)
+    if resp['code'] != 200:
+        print(
+            colored(f'Unable to delete customer with ID - {customer_id}', 'red'))
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/msp_customer_deletion/requirements.txt
+++ b/msp_customer_deletion/requirements.txt
@@ -1,0 +1,13 @@
+certifi==2023.7.22
+charset-normalizer==3.3.2
+colorama==0.4.6
+halo==0.0.31
+idna==3.4
+log-symbols==0.0.14
+pycentral==1.3
+PyYAML==6.0.1
+requests==2.31.0
+six==1.16.0
+spinners==0.0.24
+termcolor==2.3.0
+urllib3==2.0.7

--- a/msp_customer_deletion/workflow_variables.json
+++ b/msp_customer_deletion/workflow_variables.json
@@ -1,0 +1,7 @@
+{
+    "customer_ids": [ 
+    ],
+    "customer_names": [
+        "Aruba Tenant79", "Aruba Tenant791"
+    ]
+}


### PR DESCRIPTION
Customers can use this script to automate the workflow for their customer(s) - 
1. Unassign all devices & licenses from the customer's Central instance
2. Delete the customer's Central Instance & Greenlake account