### PR TITLE
Update renaming_aps.py

### DIFF
--- a/renaming_aps/renaming_aps.py
+++ b/renaming_aps/renaming_aps.py
@@ -123,7 +123,7 @@ def read_csv(file_path):
 
 		for row in csv_reader:
 			serial_numbers.append(row[0])
-			new_names.append(f'"{row[1]}"')
+			new_names.append(json.dumps(row[1]))
 	return serial_numbers, new_names
 
 @Halo(text='Checking AP Name...', spinner='simpleDots')

--- a/renaming_aps/renaming_aps.py
+++ b/renaming_aps/renaming_aps.py
@@ -123,7 +123,7 @@ def read_csv(file_path):
 
 		for row in csv_reader:
 			serial_numbers.append(row[0])
-			new_names.append(row[1])
+			new_names.append(f'"{row[1]}"')
 	return serial_numbers, new_names
 
 @Halo(text='Checking AP Name...', spinner='simpleDots')

--- a/renaming_aps/renaming_aps.py
+++ b/renaming_aps/renaming_aps.py
@@ -123,7 +123,7 @@ def read_csv(file_path):
 
 		for row in csv_reader:
 			serial_numbers.append(row[0])
-			new_names.append(json.dumps(row[1]))
+			new_names.append(json.dumps(row[1].replace('"', '')))
 	return serial_numbers, new_names
 
 @Halo(text='Checking AP Name...', spinner='simpleDots')


### PR DESCRIPTION
The current codebase sends a 200 code when names with spaces are used but does not handle them properly and the new AP name does not save properly and is not shown in Central.

This allows for spaces to be used in AP names. I have validated it with Central AOS10.